### PR TITLE
Fix: Trade not returning when config disabled

### DIFF
--- a/RandomGlobalNPC.cs
+++ b/RandomGlobalNPC.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
@@ -66,6 +66,7 @@ namespace SaneRandomizer
             if (!SaneRandomizer.Instance.Config.Trade)
             {
                 base.ModifyShop(shop);
+                return;
             }
             if (SaneRandomizer.Instance.TradeTable.ContainsKey(shop.NpcType))
             {


### PR DESCRIPTION
There was a missing `return;` statement after checking if config for Table was false. It used base.ModifyShop but since it didn't return, it ran anyway